### PR TITLE
chore: remove Prisma artifacts and update action plan

### DIFF
--- a/P11-ArgentBank/PLAN_ACTION_CI_CD_VERCEL.md
+++ b/P11-ArgentBank/PLAN_ACTION_CI_CD_VERCEL.md
@@ -65,7 +65,7 @@ direct push to main -> Vercel production deployment -> CI/CD failure after publi
 - [x] Verify whether the new Flask API implements these routes.
 - [x] Fix username updates.
 - [x] Update the Flask VPS API CORS configuration to allow Vercel preview browser requests, including `X-CSRF-Token`.
-- [ ] Clarify the current role of Upstash: still used, replaced, or removable.
+- [x] Clarify the current role of Upstash: replaced by PostgreSQL advisory locks on the Flask VPS — no longer used in the frontend.
 - [ ] Update the related Cypress tests.
 
 ## Phase 5 - Clean up documentation
@@ -95,11 +95,9 @@ direct push to main -> Vercel production deployment -> CI/CD failure after publi
 
 ## Current priority order
 
-1. Merge the protected PR after confirming all required checks are green.
-2. Clarify whether Upstash is still used, replaced, or removable.
-3. Update the related Cypress coverage if needed.
-4. Clean up documentation.
-5. Review repository architecture.
+1. Update the Cypress tests related to username update.
+2. Clean up documentation (Phase 5).
+3. Review repository architecture (Phase 6).
 
 ## Current validated status
 
@@ -108,3 +106,6 @@ direct push to main -> Vercel production deployment -> CI/CD failure after publi
 - Lighthouse desktop and mobile are blocking checks and now pass on the authenticated `/user` page.
 - The Flask VPS API at `https://db.lostintab.com/api` accepts browser requests from Vercel preview origins.
 - Username updates now work with the Flask API, including the CSRF flow.
+- Legacy Node/Vercel backend removed (`api/`, `prisma/`, `__tests__/api/`, `src/generated/prisma/`). Prisma and Upstash are no longer referenced anywhere in the frontend.
+- CI/CD workflows trigger on all branch pushes and are green on `main` after merge of PR #8.
+- Vitest coverage thresholds maintained: statements 95 / branches 90 / functions 90 / lines 95.

--- a/P11-ArgentBank/PLAN_ACTION_CI_CD_VERCEL.md
+++ b/P11-ArgentBank/PLAN_ACTION_CI_CD_VERCEL.md
@@ -66,7 +66,7 @@ direct push to main -> Vercel production deployment -> CI/CD failure after publi
 - [x] Fix username updates.
 - [x] Update the Flask VPS API CORS configuration to allow Vercel preview browser requests, including `X-CSRF-Token`.
 - [x] Clarify the current role of Upstash: replaced by PostgreSQL advisory locks on the Flask VPS — no longer used in the frontend.
-- [ ] Update the related Cypress tests.
+- [x] Update the related Cypress tests. (profile.cy.ts covers username update, cancel, and empty submission — CI green)
 
 ## Phase 5 - Clean up documentation
 
@@ -95,9 +95,8 @@ direct push to main -> Vercel production deployment -> CI/CD failure after publi
 
 ## Current priority order
 
-1. Update the Cypress tests related to username update.
-2. Clean up documentation (Phase 5).
-3. Review repository architecture (Phase 6).
+1. Clean up documentation (Phase 5).
+2. Review repository architecture (Phase 6).
 
 ## Current validated status
 


### PR DESCRIPTION
## Résumé

Nettoyage des dernières traces de l'ancien backend Node/Vercel et mise à jour du plan d'action.

## Changements

### `.env`
- Suppression des commentaires générés par `prisma init`
- Suppression de la variable `DATABASE_URL` (identifiants PostgreSQL inutiles côté frontend)

> Note : `.env` est dans `.gitignore` — ce changement est local uniquement et ne sera pas dans le diff de la PR. Il est documenté ici pour traçabilité.

### `PLAN_ACTION_CI_CD_VERCEL.md`
- Phase 4 : Upstash coché comme résolu (remplacé par advisory locks PostgreSQL côté Flask VPS)
- Priorités mises à jour (PR #8 mergée, Upstash clarifié)
- Statut validé complété : legacy supprimé, CI/CD vert sur main, seuils coverage maintenus