### PR TITLE
fix(cypress): remove redundant intercept causing race condition in transaction test

### DIFF
--- a/P11-ArgentBank/cypress/e2e/transactions/transactions-display.cy.ts
+++ b/P11-ArgentBank/cypress/e2e/transactions/transactions-display.cy.ts
@@ -162,9 +162,6 @@ describe("Transaction Display", () => {
     const targetAccountNumber = "8949";
     const accountSelector = `${selectors.accountButton}[aria-label*="${targetAccountNumber}"]`;
 
-    // Ajout de l'intercept pour la recherche par compte (plus tolérant)
-    cy.intercept("GET", "**/api/transactions/search*").as("searchByAccountApi");
-
     // Attendre la réponse de l'API comptes et logguer le body
     cy.wait("@accountsRequest").then((interception) => {
       cy.log(
@@ -218,7 +215,7 @@ describe("Transaction Display", () => {
       .should("include", accountSelectedClassName);
 
     // Attendre que l'appel API spécifique pour les transactions du compte soit fait
-    cy.wait(`@searchByAccountApi`).then((interception) => {
+    cy.wait(`@searchTransactionsRequest`).then((interception) => {
       // Log de debug sur l'URL de l'API (plus d'assertion stricte sur accountId)
       cy.log(`[DEBUG] URL API appelée: ${interception.request.url}`);
       // cy.log(`[DEBUG] Params API:`, interception.request.query);


### PR DESCRIPTION
## Problème

Le test `devrait afficher les transactions du compte sélectionné et mettre à jour l'URL` échouait de manière intermittente en CI avec l'erreur :

```
CypressError: cy.wait() timed out waiting 15000ms for the 1st request to the route: searchByAccountApi. No request ever occurred.
```

## Cause

L'intercept `searchByAccountApi` était défini **à l'intérieur du corps du test**, après que `cy.visitWithBypass('/user')` avait déjà été appelé dans le `beforeEach`. 

En CI avec `cacheAcrossSpecs: true`, la session est réutilisée et la page se charge immédiatement. L'appel API `/api/transactions/search*` part **avant** que l'intercept ne soit enregistré — Cypress rate la requête.

## Solution

Supprimer la redéfinition de l'intercept dans le corps du test et utiliser directement l'alias `@searchTransactionsRequest` déjà enregistré dans le `beforeEach` (avant `cy.visitWithBypass`).

## Changement

- `cypress/e2e/transactions/transactions-display.cy.ts` : suppression de `cy.intercept(...).as('searchByAccountApi')` et remplacement de `@searchByAccountApi` par `@searchTransactionsRequest`